### PR TITLE
Create a windows bat script for copy

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1,11 +1,11 @@
-<!-- Install ANT https://ant.apache.org/bindownload.cgi -->
+<!-- Install ANT in the PATH (https://ant.apache.org/bindownload.cgi) -->
+<!-- JAVA is also required (http://www.oracle.com/technetwork/java/javase/downloads/jre8-downloads-2133155.html) -->
+<!-- Run in a command line: ant (or ant build.xml) -->
 <project name="WTWSMS" default="copy_to_CKII_mod_folder" basedir=".">
 	<target name="copy_to_CKII_mod_folder">
 		<copy todir="${user.home}/Documents/Paradox Interactive/Crusader Kings II/mod/">
 			<fileset dir=".">
-				<exclude name="LICENSE" />
-				<exclude name="README.md" />
-				<exclude name="build.xml" />
+				<include name="WTWSMS*/**" />
 			</fileset>
 		</copy>
 	</target>

--- a/copy.bat
+++ b/copy.bat
@@ -1,0 +1,1 @@
+xcopy /d /y /c /s /e /EXCLUDE:excluded.txt "." "%HOME%\\Documents\\Paradox Interactive\\Crusader Kings II\\mod"

--- a/excluded.txt
+++ b/excluded.txt
@@ -1,0 +1,9 @@
+README.md
+.git
+.gitignore
+.gitattributes
+LICENSE
+build.xml
+copy.bat
+.project
+excluded.txt


### PR DESCRIPTION
I've created a Windows copy.bat script as an alternative to ANT script
It will copy from current director (git clone) to mod folder.
Doesn't require to install anything ;)