### PR TITLE
Fix black coa and some pagan with christian coa frame

### DIFF
--- a/WTWSMS/common/religions/00_religions.txt
+++ b/WTWSMS/common/religions/00_religions.txt
@@ -853,7 +853,7 @@ christian = {
 	arian = {
 		graphical_culture = westerngfx
 
-	        ai_convert_same_group = 1 # The Vandals were the exception, not the rule.
+        ai_convert_same_group = 1 # The Vandals were the exception, not the rule.
 
 		icon = 101
 		heresy_icon = 96
@@ -3215,7 +3215,7 @@ pagan_group = {
 
 		pre_reformed = yes
 
-                ai_convert_other_group = 2 # always try to convert
+        ai_convert_other_group = 2 # always try to convert
 
 		icon = 70
 		heresy_icon = 72
@@ -3414,7 +3414,7 @@ pagan_group = {
 
 		pre_reformed = yes
 
-                ai_convert_other_group = 2 # always try to convert
+        ai_convert_other_group = 2 # always try to convert
 
 		icon = 88
 		heresy_icon = 89		
@@ -3522,7 +3522,7 @@ pagan_group = {
 		
 		pre_reformed = yes
 
-                ai_convert_other_group = 2 # always try to convert
+        ai_convert_other_group = 2 # always try to convert
 
 		icon = 37
 		heresy_icon = 16

--- a/WTWSMS/interface/coats_of_arms.txt
+++ b/WTWSMS/interface/coats_of_arms.txt
@@ -116,7 +116,7 @@ culture =
 		texture = {
 			file = "gfx\\coats_of_arms\\dynasties4.tga"
 			size = { x = 16 y = 4 }
-			noOfFrames = 57
+			noOfFrames = 52
 			color = 0
 			random = no # Do not use for random CoAs
 		}
@@ -192,6 +192,13 @@ culture =
 			noOfFrames = 55
 			color = 3
 			emblem = no
+		}
+		texture = {
+			file = "gfx\\coats_of_arms\\dynasties4_muslim.tga"
+			size = { x = 3 y = 1 }
+			noOfFrames = 3
+			color = 0
+			random = no # Do not use for random CoAs
 		}
 	}
 }
@@ -361,6 +368,13 @@ culture = {
 	religion = {
 		"west_african_pagan_reformed"
 		"west_african_pagan"
+		"central_african_pagan_reformed"
+		"central_african_pagan"
+		"african_solar_pagan_reformed"
+		"african_solar_pagan"
+		"east_african_pagan"
+		"msoura_pagan"
+		"gurzil_pagan"
 	}
 	
 	templates = { 
@@ -512,6 +526,8 @@ culture = {
 	religion = {
 		"tengri_pagan_reformed"
 		"tengri_pagan"
+		"scythian_pagan_reformed"
+		"scythian_pagan"
 	}
 	
 	templates = { 
@@ -751,6 +767,7 @@ culture = {
 	religion = {
 		"germanic_pagan_reformed"
 		"germanic_pagan"
+		"west_pagan"
 	}
 	
 	templates = { 
@@ -809,7 +826,7 @@ culture = {
 			emblem = no
 		}
 		texture = {
-			file = "gfx\\coats_of_arms\\Germanic2_norse.tga"
+			file = "gfx\\coats_of_arms\\Germanic2.tga"
 			size = { x = 10 y = 4 }
 			noOfFrames = 32
 			color = 3
@@ -889,7 +906,7 @@ culture = {
 			emblem = no
 		}
 		texture = {
-			file = "gfx\\coats_of_arms\\Celtic2_norse.tga"
+			file = "gfx\\coats_of_arms\\Celtic2.tga"
 			size = { x = 10 y = 4 }
 			noOfFrames = 32
 			color = 3
@@ -970,6 +987,13 @@ culture = {
 			noOfFrames = 36
 			color = 3
 			emblem = no
+		}
+		texture = {
+			file = "gfx\\coats_of_arms\\dynasties4_indian.tga"
+			size = { x = 2 y = 1 }
+			noOfFrames = 2
+			color = 0
+			random = no # Do not use for random CoAs
 		}
 	}
 }


### PR DESCRIPTION
- Fix black coa due to bad index and file names on christian, germanic_pagan and celtic_pagan
- Add some pagan religions in triggers, to avoid Christian frame for pagan dynasty coa.

Note: some pagan religions are still missing: ex: hellenic_pagan, kemetic, etc. and so use Christian frame.