### PR TITLE
Fix graphical culture of Iranians, Berber and Southeast Asians #83

### DIFF
--- a/WTWSMS/common/cultures/00_cultures.txt
+++ b/WTWSMS/common/cultures/00_cultures.txt
@@ -6212,7 +6212,7 @@ central_african  = {
 	graphical_cultures = { muslimgfx }
 
 	berber = { # Berber
-		graphical_cultures = { tuareggfx muslimgfx }
+		graphical_cultures = { muslimgfx }
 
 		horde = yes
 		
@@ -6258,7 +6258,7 @@ central_african  = {
 		mother_name_chance = 30
 	}
 	guanches = { # Berber
-		graphical_cultures = { tuareggfx muslimgfx }
+		graphical_cultures = { muslimgfx }
 
 		horde = yes
 		
@@ -6304,7 +6304,7 @@ central_african  = {
 		mother_name_chance = 30
 	}
 	tashellhit = { # Berber
-		graphical_cultures = { tuareggfx muslimgfx }
+		graphical_cultures = { muslimgfx }
 
 		horde = yes
 		
@@ -6350,7 +6350,7 @@ central_african  = {
 		mother_name_chance = 30
 	}
 	tamazight = { # Berber
-		graphical_cultures = { tuareggfx muslimgfx }
+		graphical_cultures = { muslimgfx }
 
 		horde = yes
 		
@@ -6396,7 +6396,7 @@ central_african  = {
 		mother_name_chance = 30
 	}
 	riffian= { # Berber
-		graphical_cultures = { tuareggfx muslimgfx }
+		graphical_cultures = { muslimgfx }
 
 		horde = yes
 		
@@ -6442,7 +6442,7 @@ central_african  = {
 		mother_name_chance = 30
 	}
 	shenwa = { # Berber
-		graphical_cultures = { tuareggfx muslimgfx }
+		graphical_cultures = { muslimgfx }
 
 		horde = yes
 		
@@ -6488,7 +6488,7 @@ central_african  = {
 		mother_name_chance = 30
 	}
 	taqbaylit= { # Berber
-		graphical_cultures = { tuareggfx muslimgfx }
+		graphical_cultures = { muslimgfx }
 
 		horde = yes
 		
@@ -6534,7 +6534,7 @@ central_african  = {
 		mother_name_chance = 30
 	} 
 	tacawit = { # Berber
-		graphical_cultures = { tuareggfx muslimgfx }
+		graphical_cultures = { muslimgfx }
 		
 		horde = yes
 		
@@ -6580,7 +6580,7 @@ central_african  = {
 		mother_name_chance = 30
 	} 
 	nafusi = { # Berber
-		graphical_cultures = { tuareggfx muslimgfx }
+		graphical_cultures = { muslimgfx }
 
 		horde = yes
 		
@@ -6626,7 +6626,7 @@ central_african  = {
 		mother_name_chance = 30
 	} 
 	mzab_wargla= { # Berber
-		graphical_cultures = { tuareggfx muslimgfx }
+		graphical_cultures = { muslimgfx }
 
 		horde = yes
 		
@@ -6718,7 +6718,7 @@ central_african  = {
 		mother_name_chance = 30
 	}
 	garamantian = { # Berber
-		graphical_cultures = { tuareggfx muslimgfx }
+		graphical_cultures = { muslimgfx }
 		
 		horde = yes
 		
@@ -6765,7 +6765,7 @@ central_african  = {
 	}
 
 	libyan = { # Ancient Libyan
-		graphical_cultures = { tuareggfx muslimgfx }
+		graphical_cultures = { muslimgfx }
 
 		horde = yes
 		
@@ -8291,7 +8291,7 @@ east_iranian = {
 		modifier = default_culture_modifier
 	}
 	hunas = {
-		graphical_cultures = { mongolgfx } #arabicgfx
+		graphical_cultures = { persiangfx } #arabicgfx
 		horde = yes
 
 		color = { 0.1 0.4 0.0 }
@@ -8312,7 +8312,7 @@ east_iranian = {
 		modifier = default_culture_modifier
 	}
 	hepthalite = {
-		graphical_cultures = { mongolgfx } #arabicgfx
+		graphical_cultures = { persiangfx } #arabicgfx
 		horde = yes
 
 		color = { 0.0 0.3 0.0 }
@@ -8333,7 +8333,7 @@ east_iranian = {
 		modifier = default_culture_modifier
 	}
 	xionite = {
-		graphical_cultures = { mongolgfx } #arabicgfx
+		graphical_cultures = { persiangfx } #arabicgfx
 		horde = yes
 
 		color = { 0.0 0.5 0.0 }
@@ -8355,7 +8355,7 @@ east_iranian = {
 		modifier = default_culture_modifier
 	}
 	alan = {
-		graphical_cultures = { easternslavicgfx }
+		graphical_cultures = { persiangfx easternslavicgfx }
 		
 		color = { 0.7 0.5 0.7 }
 
@@ -8403,7 +8403,7 @@ east_iranian = {
 		modifier = default_culture_modifier
 	}
 	khwarezmian = {
-		graphical_cultures = { mongolgfx }
+		graphical_cultures = { persiangfx }
 
 		color = { 0.5 0.55 0.3  }
 
@@ -8625,7 +8625,7 @@ iranian = {
 		modifier = default_culture_modifier
 	}
 	sarmatian = {
-		graphical_cultures = { mongolgfx }
+		graphical_cultures = { persiangfx }
 
 		color = { 0.5 0.55 0.3  }
 
@@ -8646,7 +8646,7 @@ iranian = {
 		modifier = default_culture_modifier
 	}
 	iazyges = {
-		graphical_cultures = { mongolgfx }
+		graphical_cultures = { persiangfx }
 
 		color = { 0.7 0.55 0.73  }
 
@@ -10159,10 +10159,10 @@ proto_carpathian = {
 	}
 }
 southeast_asian_group = {
-	graphical_cultures = { indiangfx muslimgfx }
+	graphical_cultures = { mongolgfx muslimgfx }
 
 	manipuri = { 
-		graphical_cultures = { indiangfx muslimgfx }
+		graphical_cultures = { mongolgfx muslimgfx }
 		secondary_event_pictures = bengali
 		
 		color = { 0.0 0.2 0.7 }
@@ -10198,7 +10198,7 @@ southeast_asian_group = {
 		modifier = default_culture_modifier
 	}
 	arakanese = { 
-		graphical_cultures = { indiangfx muslimgfx }
+		graphical_cultures = { mongolgfx muslimgfx }
 		secondary_event_pictures = bengali
 		
 		color = { 0.0 0.1 0.5 }


### PR DESCRIPTION
This is based on suggestions from the forum:
- Use persiangfx rather than mongolgfx for Iranian group (hepthalite, hunas, khwarezmian, xionite, alan)
- Use persiangfx for sarmatian and iazyges
- Use muslimgfx rather than tuareggfx for central_african
- Use mongolgfx rather than indiangfx for southeast Asians

Some cultures are unknown to me, so could you please review if these changes makes sense ?